### PR TITLE
omit appending @ to user id if no default domain is provided

### DIFF
--- a/lib/Service/Config.php
+++ b/lib/Service/Config.php
@@ -310,11 +310,11 @@ class Config
     $userEmail = null;
     $userPassword = null;
     $emailAddressChoice = $this->getAppValue('emailAddressChoice', 'userPreferencesEmail');
+    $emailDefaultDomain = $this->getAppValue('emailDefaultDomain', '');
     switch ($emailAddressChoice) {
       case self::EMAIL_ADDRESS_CHOICE_USER_ID:
         $userEmail = $this->user->getUID();
-        if (strpos($userEmail, '@') === false) {
-          $emailDefaultDomain = $this->getAppValue('emailDefaultDomain', '');
+        if (strpos($userEmail, '@') === false && !empty($emailDefaultDomain)) {
           $userEmail .= '@'.$emailDefaultDomain;
         }
         break;

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -71,7 +71,7 @@ class Personal implements ISettings
     switch ($emailAddressChoice) {
       case 'userIdEmail':
         $userEmail = $this->user->getUID();
-        if (strpos($userEmail, '@') === false) {
+        if (strpos($userEmail, '@') === false && !empty($emailDefaultDomain)) {
           $userEmail .= '@'.$emailDefaultDomain;
         }
         break;


### PR DESCRIPTION
This change is useful for organization environments where the users login id isn't an email address, as
the current code adds a @ after the user id even if no default domain is provided in the plugins settings.