### PR TITLE
Add Nextcloud 33 compatibility

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
   <category>social</category>+
   <dependencies>
     <php min-version="8.1" max-version="8.4" />
-    <nextcloud min-version="30" max-version="32" />
+    <nextcloud min-version="30" max-version="33" />
   </dependencies>
   <bugs>https://github.com/rotdrop/nextcloud-roundcube/issues</bugs>
   <website>https://github.com/rotdrop/nextcloud-roundcube/</website>


### PR DESCRIPTION
Bump `max-version` from 32 to 33 in `appinfo/info.xml` to allow installation on Nextcloud 33.

Tested on Nextcloud 33.0.0 with PHP 8.4.19:
- App enables and disables cleanly (no `--force` needed)
- No deprecated API usage detected (scoped toolkit regenerates correctly with the existing `IAppContainer` → `Psr\ContainerInterface` fix from c1b0aa8)
- No `IQueryBuilder::execute()` calls (already using `executeQuery()`/`executeStatement()`)
- Frontend loads without PHP errors

Relates to #63